### PR TITLE
Changing contract address from operator to registry

### DIFF
--- a/src/plasma.js
+++ b/src/plasma.js
@@ -6,7 +6,8 @@ const defaultOptions = {
   operatorProvider: services.OperatorProviders.DefaultOperatorProvider,
   walletProvider: services.WalletProviders.DefaultWalletProvider,
   contractProvider: services.ContractProviders.DefaultContractProvider,
-  web3Provider: services.Web3Provider
+  web3Provider: services.Web3Provider,
+  registryAddress: services.defaultRegistryAddress
 }
 
 /**

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -13,6 +13,8 @@ const WalletProviders = require('./wallet/index')
 const Web3Provider = require('./web3-provider')
 const EventHandler = require('./contract/events/event-handler')
 const EventWatcher = require('./contract/events/event-watcher')
+// Should this address value perhaps be kept in a seperate file?
+const defaultRegistryAddress = '0xA1f90e4933F9AF055e4a309DB54316552E7Fd10c'
 
 module.exports = {
   BaseService,
@@ -28,6 +30,7 @@ module.exports = {
   ProofService,
   WalletProviders,
   Web3Provider,
+  EventHandler,
   EventWatcher,
-  EventHandler
+  defaultRegistryAddress
 }


### PR DESCRIPTION
Hello,

I spent time looking through the plasma-core project to ensure that I could insert this in a clean way which would wrap around most of the other components. I wasn't sure whether to make a new service and extend base-service/base-provider, but concluded it may be overkill for the moment.

There is also room for a registry contract address fallback, which can be defined. I have placed a random address there for now, I thought it might be good to hardcode for safety? This would be for a safe default contract address that can be queried. 

Please let me know if there's anything more I can do, I tried to make sure I maximized this addition.

Tasks completed:
[✓] Query contract address from registry.
[✓] Remove old method of querying from operator.

Thank you!
Luiserebii